### PR TITLE
Update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - fastapi >=0.65.0,<1.0
     - fsspec
     - h2 >3,<4.0.0
+    - httpx ~=0.20.0
     - importlib-metadata >=4.8,<5
     - itsdangerous
     - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - quetz = quetz.cli:app
@@ -46,7 +46,7 @@ requirements:
     - ujson
     - uvicorn
     - xattr
-    - authlib
+    - authlib<1.0.0
     - zstandard
     - pamela
     - sqlite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - ujson
     - uvicorn
     - xattr
-    - authlib<1.0.0
+    - authlib <1.0.0
     - zstandard
     - pamela
     - sqlite


### PR DESCRIPTION
Quetz-frontend recipe is failing because of authlib<1.0.0 
We updated the python package in v0.4.4 but we forgot to update the recipe, see https://github.com/mamba-org/quetz/blob/d63e2f155aa75dfe852b70674b01ab7732d234c2/setup.cfg#L26

same for httpx.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
